### PR TITLE
Add ffmpeg as package to patch Streamlit cloud deployment

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,1 +1,2 @@
 weasyprint
+ffmpeg


### PR DESCRIPTION
ffmpeg is not installed in streamlit cloud leading to an error