### PR TITLE
Add replit hosting support

### DIFF
--- a/.replit
+++ b/.replit
@@ -7,3 +7,11 @@ channel = "stable-23_11"
 [deployment]
 run = ["sh", "-c", "echo \"\" | python -m streamlit run main.py"]
 deploymentTarget = "cloudrun"
+
+[[ports]]
+localPort = 8501
+externalPort = 80
+
+[[ports]]
+localPort = 8502
+externalPort = 3000

--- a/.replit
+++ b/.replit
@@ -1,0 +1,9 @@
+modules = ["python-3.12"]
+run = "python -m streamlit run main.py"
+
+[nix]
+channel = "stable-23_11"
+
+[deployment]
+run = ["sh", "-c", "echo \"\" | python -m streamlit run main.py"]
+deploymentTarget = "cloudrun"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Groqnotes is a streamlit app that scaffolds the creation of structured lecture n
 
 To use Groqnotes, you can use the hosted version at [groqnotes.streamlit.app](https://groqnotes.streamlit.app)
 
+### Hosted on Replit:
+
+Alternatively, you can use the hosted version on replit at [groqnotes.replit.app](https://groqnotes.streamlit.app)
+> You can fork the project on replit here: [replit.com/@bklieger/groqnotes](https://replit.com/@bklieger/groqnotes)
+
 
 ### Run locally:
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Groqnotes is a streamlit app that scaffolds the creation of structured lecture n
 ## Quickstart
 
 > [!IMPORTANT]
-> To use Groqnotes, you can use the hosted version at [groqnotes.streamlit.app](https://groqnotes.streamlit.app)
-> Alternatively, you can run groqnotes locally with streamlit using the quickstart instructions.
+> To use Groqnotes, you can use a hosted version at [groqnotes.streamlit.app](https://groqnotes.streamlit.app) or [groqnotes.replit.app](https://groqnotes.streamlit.app).
+> Alternatively, you can run groqnotes locally with Streamlit using the quickstart instructions.
 
 
 ### Hosted on Streamlit:
@@ -41,8 +41,8 @@ To use Groqnotes, you can use the hosted version at [groqnotes.streamlit.app](ht
 
 ### Hosted on Replit:
 
-Alternatively, you can use the hosted version on replit at [groqnotes.replit.app](https://groqnotes.streamlit.app)
-> You can fork the project on replit here: [replit.com/@bklieger/groqnotes](https://replit.com/@bklieger/groqnotes)
+You can also use the hosted version on replit at [groqnotes.replit.app](https://groqnotes.streamlit.app)
+> The project can be forked on replit here: [replit.com/@bklieger/groqnotes](https://replit.com/@bklieger/groqnotes)
 
 
 ### Run locally:

--- a/replit.nix
+++ b/replit.nix
@@ -24,8 +24,6 @@
     pkgs.pkg-config
     pkgs.arrow-cpp
     pkgs.ghostscript
-    pkgs.python3
-    pkgs.python3Packages.weasyprint
     pkgs.ffmpeg
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,31 @@
+{ pkgs }: {
+  deps = [
+    pkgs.libffi
+    pkgs.zlib
+    pkgs.tk
+    pkgs.tcl
+    pkgs.openjpeg
+    pkgs.libxcrypt
+    pkgs.libwebp
+    pkgs.libtiff
+    pkgs.libjpeg
+    pkgs.libimagequant
+    pkgs.lcms2
+    pkgs.freetype
+    pkgs.pango
+    pkgs.harfbuzz
+    pkgs.glib
+    pkgs.fontconfig
+    pkgs.rustc
+    pkgs.libiconv
+    pkgs.cargo
+    pkgs.cacert
+    pkgs.glibcLocales
+    pkgs.pkg-config
+    pkgs.arrow-cpp
+    pkgs.ghostscript
+    pkgs.python3
+    pkgs.python3Packages.weasyprint
+    pkgs.ffmpeg
+  ];
+}


### PR DESCRIPTION
You can now access the hosted version of GroqNotes on Replit or fork the project here: [replit.com/@bklieger/groqnotes](https://replit.com/@bklieger/groqnotes)