### PR TITLE
docs: Adding one-click deploy button for RepoCloud.io to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Finally, you can run the streamlit app.
 python3 -m streamlit run main.py
 ~~~
 
+## One-Click Deployment
+
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=296)
 
 ## Details
 


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud.io with one click.