### PR TITLE
Optimize Transcription with YouTube Captions, Audio Resampling, and Copy Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 venv
 .venv
 **.pyc
-downloads/
+downloads/.DS_Store

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+scribewizard

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Streamlit",
+            "type": "python",
+            "request": "launch",
+            "module": "streamlit",
+            "args": [
+                "run",
+                "main.py"
+            ],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Streamlit",
+            "type": "shell",
+            "command": "python3",
+            "args": [
+                "-m",
+                "streamlit",
+                "run",
+                "main.py"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [],
+            "detail": "Runs the Streamlit app using the Python module command."
+        }
+    ]
+}

--- a/main.py
+++ b/main.py
@@ -287,7 +287,7 @@ def get_youtube_captions(youtube_link):
     match = re.search(pattern, youtube_link)
     if match:
         video_id = match.group(1)
-        transcript = YouTubeTranscriptApi.get_transcript(video_id)
+        transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=('en', 'pt'))
         return ' '.join([entry['text'] for entry in transcript])
     else:
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,5 @@ webencodings==0.5.1
 websockets==12.0
 yt-dlp @ https://github.com/yt-dlp/yt-dlp/archive/master.tar.gz
 zopfli==0.2.3
+youtube_transcript_api
+pyperclip

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,1 @@
+python3 -m streamlit run main.py


### PR DESCRIPTION
PR Changes:

- Use youtube captions (auto-captions included) when available to avoid the audio transcription when possible.
- Resample mp3 from 192Khz to 48Kh before the transcription if the audio file is larger than 25MB (current Whisper+Groq limit)
- Add a "Copy" button at the bottom of the page when the summarization is finished to easily copy the content.