### PR TITLE
Fixes #34: Update max file size limit from 25MB to 100MB

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,2 @@
 [server]
-maxUploadSize = 25
+maxUploadSize = 100

--- a/download.py
+++ b/download.py
@@ -5,8 +5,8 @@ import time
 import os
 import shutil
 
-MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
-FILE_TOO_LARGE_MESSAGE = "The audio file is too large for the current size and rate limits using Whisper. If you used a YouTube link, please try a shorter video clip. If you uploaded an audio file, try trimming or compressing the audio to under 25 MB."
+MAX_FILE_SIZE = 100 * 1024 * 1024  # 100 MB
+FILE_TOO_LARGE_MESSAGE = "The audio file is too large for the current size and rate limits using Whisper. If you used a YouTube link, please try a shorter video clip. If you uploaded an audio file, try trimming or compressing the audio to under 100 MB."
 max_retries = 3
 delay = 2
 

--- a/main.py
+++ b/main.py
@@ -5,15 +5,11 @@ import os
 from io import BytesIO
 from md2pdf.core import md2pdf
 from dotenv import load_dotenv
-from download import download_video_audio, delete_download
+from download import download_video_audio, delete_download, MAX_FILE_SIZE, FILE_TOO_LARGE_MESSAGE
 
 load_dotenv()
 
 GROQ_API_KEY = os.environ.get("GROQ_API_KEY", None)
-
-MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
-FILE_TOO_LARGE_MESSAGE = "The audio file is too large for the current size and rate limits using Whisper. If you used a YouTube link, please try a shorter video clip. If you uploaded an audio file, try trimming or compressing the audio to under 25 MB."
-
 audio_file_path = None
 
 if 'api_key' not in st.session_state:


### PR DESCRIPTION
- Updated file size limit from 25MB to 100MB to match Groq's new limits:
  - Changed MAX_FILE_SIZE in download.py
  - Updated FILE_TOO_LARGE_MESSAGE to reflect new limit
  - Updated Streamlit config.toml maxUploadSize
  - Tested with files of various sizes to verify changes work correctly



